### PR TITLE
Handle linearized files correctly

### DIFF
--- a/pdf.c
+++ b/pdf.c
@@ -763,7 +763,6 @@ static void resolve_linearized_pdf(pdf_t *pdf)
     /* Swap Linear with Version 1 */
     buf = pdf->xrefs[0];
     pdf->xrefs[0] = pdf->xrefs[1];
-    pdf->xrefs[1] = buf;
 
     /* Resolve is_linear flag and version */
     pdf->xrefs[0].is_linear = 1;


### PR DESCRIPTION
pdfresurrect fails to recover versions correctly on linearized files. This PR fixes that.

## Description
When creating version 1 of a linearized file, pdfresurrect sets the xref offset to 0 in the trailer. But really the offset should be to the first xref table.

## Related Issues
pdfresurrect still crashes sometimes ( https://github.com/InscribeAI/inscribe-app/issues/164 ). The enferex version has actually been updated in the past few months with claimed improvements, but as far as I can tell this doesn't actual fix any of the issues we've been having.